### PR TITLE
build: bump eslint-config-prettier to 8.1.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,10 +18,7 @@
     "plugin:prettier/recommended",
     "plugin:unicorn/recommended",
     "plugin:cypress/recommended",
-    "prettier",
-    "prettier/react",
-    "prettier/unicorn",
-    "prettier/@typescript-eslint"
+    "prettier"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cypress": "^6.5.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.20.0",
-    "eslint-config-prettier": "^7.2.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-cypress": "^2.11.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3822,10 +3822,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
-  integrity sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
+eslint-config-prettier@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz#4ef1eaf97afe5176e6a75ddfb57c335121abc5a6"
+  integrity sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==
 
 eslint-import-resolver-node@^0.3.4:
   version "0.3.4"


### PR DESCRIPTION
Bumps eslint-config-prettier and removes deprecated rules.

closes #38