### PR TITLE
feat: add custom errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "redux-logger": "^3.0.6",
     "redux-saga": "^1.1.3",
     "styled-breakpoints": "^9.0.12",
+    "ts-custom-error": "^3.2.0",
     "use-dark-mode": "^2.3.1"
   },
   "devDependencies": {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,10 @@
+import { CustomError } from 'ts-custom-error';
+
+class HttpError extends CustomError {
+  public constructor(public code: number, message?: string) {
+    super(message);
+    Object.defineProperty(this, 'name', { value: 'HttpError' });
+  }
+}
+
+export { HttpError };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10589,6 +10589,11 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
+ts-custom-error@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ts-custom-error/-/ts-custom-error-3.2.0.tgz#ff8f80a3812bab9dc448536312da52dce1b720fb"
+  integrity sha512-cBvC2QjtvJ9JfWLvstVnI45Y46Y5dMxIaG1TDMGAD/R87hpvqFL+7LhvUDhnRCfOnx/xitollFWWvUKKKhbN0A==
+
 ts-node@^9.1.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"


### PR DESCRIPTION
Adds a custom HTTP error with ts-custom-error.

closes #51