### PR TITLE
feat: add login handler

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,1 +1,2 @@
+MAGIC_SECRET_KEY=sk_test_<get-your-own>
 TOKEN_SECRET=some-secret-which-is-at-least-32-characters-long

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,6 +30,9 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: 'Run ${{ matrix.command }}'
         run: yarn ${{ matrix.command }}
+        env:
+          MAGIC_SECRET_KEY: ${{ secrets.MAGIC_SECRET_KEY }}
+          TOKEN_SECRET: ${{ secrets.TOKEN_SECRET }}
 
   e2e-tests:
     runs-on: ubuntu-latest
@@ -40,6 +43,10 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           start: yarn dev
+        env:
+          MAGIC_SECRET_KEY: ${{ secrets.MAGIC_SECRET_KEY }}
+          TOKEN_SECRET: ${{ secrets.TOKEN_SECRET }}
+          CYPRESS_validToken: ${{ secrets.VALID_TOKEN }}
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/cypress/e2e/user-authentication.spec.ts
+++ b/cypress/e2e/user-authentication.spec.ts
@@ -1,0 +1,92 @@
+import { extractCookies } from 'utils/extract-cookies';
+
+import validateForbiddenMethods from '../support/utils';
+
+const loginRoute = `/api/login`;
+
+describe('login handler', () => {
+  context('GET', () => {
+    it('returns a 200 and logs the user in with a valid token', () => {
+      cy.request({
+        url: loginRoute,
+        auth: { bearer: Cypress.env('validToken') },
+      }).then(response => {
+        expect(response.status).to.equal(200);
+        const magicToken = extractCookies(response.headers)['magic-auth-token'];
+        expect(magicToken.value.length).to.equal(420);
+        expect(response.body).to.deep.equal({ done: true });
+      });
+    });
+
+    it('returns a 400 when a valid token is included wrongly', () => {
+      cy.request({
+        url: loginRoute,
+        headers: { Authorization: Cypress.env('validToken') },
+        failOnStatusCode: false,
+      }).then(response => {
+        expect(response.status).to.equal(400);
+
+        const actual = response.body;
+        const expected = {
+          message:
+            "Malformed authorization header. It should be: 'Bearer ${token}'.",
+        };
+
+        expect(actual).to.deep.equal(expected);
+      });
+    });
+
+    it('returns a 400 when the token is missing', () => {
+      cy.request({
+        url: loginRoute,
+        failOnStatusCode: false,
+      }).then(response => {
+        expect(response.status).to.equal(400);
+
+        const actual = response.body;
+        const expected = { message: 'No token found in request.' };
+
+        expect(actual).to.deep.equal(expected);
+      });
+    });
+
+    it('returns a 400 when the token is malformed', () => {
+      const malformedDidToken = 'abc-123';
+
+      cy.request({
+        url: loginRoute,
+        auth: { bearer: malformedDidToken },
+        failOnStatusCode: false,
+      }).then(response => {
+        expect(response.status).to.equal(400);
+
+        const actual = response.body;
+        const expected = {
+          message: 'Malformed token. Please include a valid DID token.',
+        };
+
+        expect(actual).to.deep.equal(expected);
+      });
+    });
+
+    it('returns a 401 when the token is invalid', () => {
+      const invalidDidToken =
+        'WyIweGUxN2U2MTk0M2Q0NTdiOWQ4NmJhMTRiNWU4YjkxMmZkNjRlMDY3ZThiMWNmOGIzZGM0ZDcxOTNkNTA4YmE1MTE3ZjRhNjY2NWYwMzhjM2YwZjg5ODRjNTZkMTY0OWRmYmJmMjg2MjNkMjM0ZDY1Zjc0NjAwYWY2M2YzNDI0NDdjMWIiLCJ7XCJpYXRcIjoxNjEwNDkxNjM2LFwiZXh0XCI6MS4wMDAwMDAwMDAwMDE2MTA1ZSsyMSxcImlzc1wiOlwiZGlkOmV0aHI6MHg3RjBBN2I4OTAzMUU0NzFiODNmMmJhRTFBZkFFOTEwYzA1MDQ0NEFDXCIsXCJzdWJcIjpcIjJUTWoxMFZSb1JfU0t0eEpheVhyME8wUEdNUEw3Sjl1RjlOV2dDdWwySkE9XCIsXCJhdWRcIjpcIjhUZUNjSWxWVWtuaG1HME5yVmlqZkVqRnJvOU9VRDBZam1td0twYkQ0MFE9XCIsXCJuYmZcIjoxNjEwNDkxNjM2LFwidGlkXCI6XCJlMDlmZWJkZC1jNzRlLTRhY2EtYjk1MC05MTAwZjJjNjI5OGVcIixcImFkZFwiOlwiMHhmOGIwMmRlYTRiZDhhMzZhMjA3YjA5MWIxNjNjNzQ5NzE3YmJkMWM1NjgyZGU0MDJlODhiY2JiZmNjZTQ0YjZmNjUzYWVlM2EwZGIzNDA4OWM3NDBmZjFmYTMwZDI4ZDU1NjNiODMzYzk2Mzc0NmQ2NzNmYTI3MTJiOGVlMjY4NDFiXCJ9Il0';
+
+      cy.request({
+        url: loginRoute,
+        auth: { bearer: invalidDidToken },
+        failOnStatusCode: false,
+      }).then(response => {
+        expect(response.status).to.equal(401);
+
+        const actual = response.body;
+        const expected = { message: 'Not authorized' };
+
+        expect(actual).to.deep.equal(expected);
+      });
+    });
+  });
+
+  validateForbiddenMethods(['POST', 'PUT', 'DELETE'], loginRoute);
+});

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -1,0 +1,36 @@
+/* eslint-disable jest/valid-expect */
+/* eslint-disable jest/valid-expect-in-promise */
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+/**
+ * Checks if forbidden methods for a route return the status code 405.
+ * @param forbiddenMethods - An array of HTTP methods that should be forbidden.
+ * @param route - The route under test.
+ */
+const validateForbiddenMethods = (
+  forbiddenMethods: HttpMethod[],
+  route: string,
+) => {
+  forbiddenMethods.forEach(method => {
+    context(method, () => {
+      it('returns a 405 with an error message', () => {
+        cy.request({
+          method: method,
+          url: route,
+          failOnStatusCode: false,
+        }).then(response => {
+          expect(response.body).to.haveOwnProperty('message');
+
+          const actual = response.status;
+          const expected = 405;
+
+          expect(actual).to.deep.equal(expected);
+        });
+      });
+    });
+  });
+};
+
+// eslint-disable-next-line jest/no-export
+export default validateForbiddenMethods;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@hapi/iron": "^6.0.0",
+    "@magic-sdk/admin": "^1.3.0",
     "@reduxjs/toolkit": "^1.5.0",
     "cookie": "^0.4.1",
     "next": "10.0.7",

--- a/src/features/user-authentication/login-handler.ts
+++ b/src/features/user-authentication/login-handler.ts
@@ -1,0 +1,60 @@
+import { MagicAdminSDKError } from '@magic-sdk/admin/dist/core/sdk-exceptions';
+import type { NextApiHandler } from 'next';
+import { setTokenCookie } from 'utils/cookies';
+import magic from 'utils/magic';
+import { encryptSession } from 'utils/sessions';
+import type { ApiErrorResponse } from 'utils/types';
+
+type SuccessResponse = {
+  done: true;
+};
+
+type LoginHandlerResponse = ApiErrorResponse | SuccessResponse;
+
+const loginHandler: NextApiHandler<LoginHandlerResponse> = async (
+  request,
+  response,
+) => {
+  try {
+    if (request.method === 'GET') {
+      const authHeaders = request.headers.authorization;
+
+      if (authHeaders) {
+        const didToken = magic.utils.parseAuthorizationHeader(authHeaders);
+        const metadata = await magic.users.getMetadataByToken(didToken);
+        const session = { ...metadata };
+        const token = await encryptSession(session);
+        setTokenCookie(response, token);
+        return response.status(200).json({ done: true });
+      }
+
+      return response
+        .status(400)
+        .json({ message: 'No token found in request.' });
+    }
+
+    const message = 'This endpoint only supports the GET method.';
+    return response.status(405).json({ message });
+  } catch (error) {
+    if (error instanceof MagicAdminSDKError) {
+      if (error.message.includes('`Bearer {token}`')) {
+        const message =
+          "Malformed authorization header. It should be: 'Bearer ${token}'.";
+        return response.status(400).json({ message });
+      }
+
+      if (error.message.includes('malformed')) {
+        const message = 'Malformed token. Please include a valid DID token.';
+        return response.status(400).json({ message });
+      }
+
+      if (error?.data[0]?.message?.includes('not authorized')) {
+        return response.status(401).json({ message: 'Not authorized' });
+      }
+    }
+
+    return response.status(error.code || 500).json({ message: error.message });
+  }
+};
+
+export default loginHandler;

--- a/src/pages/api/hello.ts
+++ b/src/pages/api/hello.ts
@@ -1,8 +1,0 @@
-import type { NextApiHandler } from 'next';
-
-const handler: NextApiHandler<{ name: string }> = (request, response) => {
-  response.statusCode = 200;
-  response.json({ name: 'John Doe' });
-};
-
-export default handler;

--- a/src/pages/api/login.ts
+++ b/src/pages/api/login.ts
@@ -1,0 +1,3 @@
+import loginHandler from 'features/user-authentication/login-handler';
+
+export default loginHandler;

--- a/src/utils/extract-cookies.test.ts
+++ b/src/utils/extract-cookies.test.ts
@@ -1,0 +1,109 @@
+import { extractCookies, shapeFlags } from './extract-cookies';
+
+const sampleHeaders = {
+  vary: 'Origin',
+  'access-control-allow-credentials': 'true',
+  'set-cookie': [
+    'refresh_token=s%3AeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJVMkZzZEdWa1gxOVBEL0RqVUlXV2lvUmZhWlhuWWdJTExaUGJ2cW4xcWRVPSIsImlhdCI6MTU2MjIwMTAzNywiZXhwIjoxNTYyODA1ODM3LCJpc3MiOiJsb2NhbGhvc3QiLCJqdGkiOiI5MmQzMmY4Ni05ZmYzLTQ5OTgtOWE1Zi1jZDNkZWU1YTRmYmQifQ.6omhdrHChv4cPhfhvwz6xMK7RPsc-SCtWxHTIkBLRrw.kaJG83X6V9YBHwYPlCQ61X7KOsX7wFSfD7hnEdP0pmg; Domain=localhost; Path=/tokens; HttpOnly; SameSite=Strict',
+  ],
+  etag: 'W/"a-bAsFyilMr4Ra1hIU5PyoyFRunpI"',
+  date: 'Thu, 04 Jul 2019 00:43:57 GMT',
+  connection: 'close',
+};
+
+describe('shapeFlags: shapes an array of ["Flag=Value"] pairs into an object', () => {
+  const [, ...flags] = sampleHeaders['set-cookie'][0].split('; ');
+  const output = shapeFlags(flags);
+
+  it('returns an object of { flag: value } entries', () =>
+    Object.entries({
+      Domain: 'localhost',
+      Path: '/tokens',
+      HttpOnly: true,
+      SameSite: 'Strict',
+    }).forEach(flagEntry => {
+      const [flagName, expected] = flagEntry;
+
+      const actual = output[flagName];
+
+      expect(actual).toEqual(expected);
+    }));
+
+  it('sets value to true for flags without values (boolean flags)', () => {
+    const actual = output.HttpOnly;
+    const expected = true;
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('given a cookie with a single flag: should strip the trailing ";" character', () => {
+    const singleFlagHeaders = {
+      'set-cookie': ['cookiename=cookievalue; Domain=oneflag'],
+    };
+    const [, ...flags] = singleFlagHeaders['set-cookie'][0].split('; ');
+
+    const actual = shapeFlags(flags);
+    const expected = { Domain: 'oneflag' };
+
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('extractCookies: extracts and shapes response cookies from the set-cookie header', () => {
+  const output = extractCookies(sampleHeaders);
+
+  it('returns an object of { cookieName: { value, flags } } shape', () => {
+    expect(output.refresh_token).toBeDefined();
+    expect(output.refresh_token.value).toBeDefined();
+    expect(output.refresh_token.flags).toBeDefined();
+  });
+
+  it('extracts the value of a given cookie', () => {
+    const actual = output.refresh_token.value;
+    const expected =
+      's%3AeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJVMkZzZEdWa1gxOVBEL0RqVUlXV2lvUmZhWlhuWWdJTExaUGJ2cW4xcWRVPSIsImlhdCI6MTU2MjIwMTAzNywiZXhwIjoxNTYyODA1ODM3LCJpc3MiOiJsb2NhbGhvc3QiLCJqdGkiOiI5MmQzMmY4Ni05ZmYzLTQ5OTgtOWE1Zi1jZDNkZWU1YTRmYmQifQ.6omhdrHChv4cPhfhvwz6xMK7RPsc-SCtWxHTIkBLRrw.kaJG83X6V9YBHwYPlCQ61X7KOsX7wFSfD7hnEdP0pmg';
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('extracts and shapes the flags of the cookie', () => {
+    const [, ...flags] = sampleHeaders['set-cookie'][0].split('; ');
+
+    const actual = output.refresh_token.flags;
+    const expected = shapeFlags(flags);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('cookie has no additional flags: cookieName.flags is an empty object', () => {
+    const noFlagsHeaders = {
+      'set-cookie': [
+        'refresh_token=s%3AeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJVMkZzZEdWa1gxOVBEL0RqVUlXV2lvUmZhWlhuWWdJTExaUGJ2cW4xcWRVPSIsImlhdCI6MTU2MjIwMTAzNywiZXhwIjoxNTYyODA1ODM3LCJpc3MiOiJsb2NhbGhvc3QiLCJqdGkiOiI5MmQzMmY4Ni05ZmYzLTQ5OTgtOWE1Zi1jZDNkZWU1YTRmYmQifQ.6omhdrHChv4cPhfhvwz6xMK7RPsc-SCtWxHTIkBLRrw.kaJG83X6V9YBHwYPlCQ61X7KOsX7wFSfD7hnEdP0pmg;',
+      ],
+    };
+    const output = extractCookies(noFlagsHeaders);
+
+    const actual = output.refresh_token.flags;
+    const expected = {};
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('supports multiple cookie entries', () => {
+    const multipleCookiesHeaders = {
+      'set-cookie': [
+        'someothercookie=cookievalue; Domain=test;',
+        'refresh_token=s%3AeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJVMkZzZEdWa1gxOVBEL0RqVUlXV2lvUmZhWlhuWWdJTExaUGJ2cW4xcWRVPSIsImlhdCI6MTU2MjIwMTAzNywiZXhwIjoxNTYyODA1ODM3LCJpc3MiOiJsb2NhbGhvc3QiLCJqdGkiOiI5MmQzMmY4Ni05ZmYzLTQ5OTgtOWE1Zi1jZDNkZWU1YTRmYmQifQ.6omhdrHChv4cPhfhvwz6xMK7RPsc-SCtWxHTIkBLRrw.kaJG83X6V9YBHwYPlCQ61X7KOsX7wFSfD7hnEdP0pmg;',
+      ],
+    };
+
+    const output = extractCookies(multipleCookiesHeaders);
+
+    ['refresh_token', 'someothercookie'].forEach(cookieName =>
+      expect(output[cookieName]).toBeDefined(),
+    );
+
+    expect(output.someothercookie.value).toEqual('cookievalue');
+    expect(output.someothercookie.flags).toEqual({ Domain: 'test' });
+  });
+});

--- a/src/utils/extract-cookies.ts
+++ b/src/utils/extract-cookies.ts
@@ -1,0 +1,31 @@
+const shapeFlags = (flags: string[]): Record<string, unknown> =>
+  flags.reduce((shapedFlags, flag) => {
+    const [flagName, rawValue] = flag.split('=');
+    // edge case where a cookie has a single flag and "; " split results in trailing ";"
+    const value = rawValue ? rawValue.replace(';', '') : true;
+    return { ...shapedFlags, [flagName]: value };
+  }, {});
+
+type CookieHeaders = {
+  'set-cookie'?: string[];
+} & Record<string, unknown>;
+
+type Cookie = {
+  value: string;
+  flags: Record<string, unknown>;
+};
+
+const extractCookies = (headers: CookieHeaders): Record<string, Cookie> => {
+  const cookies: string[] = headers['set-cookie'] ?? [];
+
+  return cookies.reduce((shapedCookies, cookieString) => {
+    const [rawCookie, ...flags] = cookieString.split('; ');
+    const [cookieName, value] = rawCookie.split('=');
+    return {
+      ...shapedCookies,
+      [cookieName]: { value, flags: shapeFlags(flags) },
+    };
+  }, {});
+};
+
+export { extractCookies, shapeFlags };

--- a/src/utils/magic.ts
+++ b/src/utils/magic.ts
@@ -1,0 +1,5 @@
+import { Magic } from '@magic-sdk/admin';
+
+const magic = new Magic(process.env.MAGIC_SECRET_KEY);
+
+export default magic;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,1 +1,3 @@
 export type Factory<Shape> = (state?: Partial<Shape>) => Shape;
+
+export type ApiErrorResponse = { message: string };

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,6 +891,16 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@magic-sdk/admin@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@magic-sdk/admin/-/admin-1.3.0.tgz#08d53aa39f94090221999be60660bdc50b8e6e12"
+  integrity sha512-PcDP+8i82p7e+oSohqE5dPoRyymEsoOcXaAKxK7S13TypVf1lxf4MCpBBQI7Q+nFwNa4zTRcaE6QaDdvruBDKA==
+  dependencies:
+    eth-sig-util "2.1.2"
+    ethereumjs-util "^6.2.0"
+    express "^4.17.1"
+    node-fetch "^2.6.0"
+
 "@next/env@10.0.7":
   version "10.0.7"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-10.0.7.tgz#7b3e87a9029ca37491e2ec25c27593f0906725f9"
@@ -1343,6 +1353,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bn.js@^4.11.3":
+  version "4.11.6"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
+  integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/body-parser@*":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
@@ -1482,6 +1499,13 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/pbkdf2@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/pbkdf2/-/pbkdf2-3.1.0.tgz#039a0e9b67da0cdc4ee5dab865caa6b267bb66b1"
+  integrity sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/prettier@^2.0.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.1.tgz#374e31645d58cb18a07b3ecd8e9dede4deb2cccd"
@@ -1531,6 +1555,13 @@
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
+"@types/secp256k1@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-4.0.1.tgz#fb3aa61a1848ad97d7425ff9dcba784549fca5a4"
+  integrity sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==
+  dependencies:
+    "@types/node" "*"
 
 "@types/serve-static@*":
   version "1.13.9"
@@ -2220,6 +2251,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base-x@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
+  integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -2281,6 +2319,11 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+blakejs@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
+  integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
+
 blob-util@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/blob-util/-/blob-util-2.0.2.tgz#3b4e3c281111bb7f11128518006cdc60b403a1eb"
@@ -2295,6 +2338,11 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.11.9"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
+
+bn.js@^4.10.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.8.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
 bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.1.3"
@@ -2376,7 +2424,7 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserify-aes@^1.0.0, browserify-aes@^1.0.4:
+browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
   integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
@@ -2448,6 +2496,22 @@ browserslist@4.16.1:
     escalade "^3.1.1"
     node-releases "^1.1.69"
 
+bs58@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
+  dependencies:
+    base-x "^3.0.2"
+
+bs58check@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
+  integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
+  dependencies:
+    bs58 "^4.0.0"
+    create-hash "^1.1.0"
+    safe-buffer "^5.1.2"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -2487,7 +2551,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.5.0:
+buffer@^5.2.1, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -3827,7 +3891,7 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
-elliptic@^6.5.3:
+elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -4275,6 +4339,92 @@ etag@1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+eth-sig-util@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.1.2.tgz#9b357395b5ca07fae6b430d3e534cf0a0f1df118"
+  integrity sha512-bNgt7txkEmaNlLf+PrbwYIdp4KRkB3E7hW0/QwlBpgv920pVVyQnF0evoovfiRveNKM4OrtPYZTojjmsfuCUOw==
+  dependencies:
+    buffer "^5.2.1"
+    elliptic "^6.4.0"
+    ethereumjs-abi "0.6.5"
+    ethereumjs-util "^5.1.1"
+    tweetnacl "^1.0.0"
+    tweetnacl-util "^0.15.0"
+
+ethereum-cryptography@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz#8d6143cfc3d74bf79bbd8edecdf29e4ae20dd191"
+  integrity sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==
+  dependencies:
+    "@types/pbkdf2" "^3.0.0"
+    "@types/secp256k1" "^4.0.1"
+    blakejs "^1.1.0"
+    browserify-aes "^1.2.0"
+    bs58check "^2.1.2"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    hash.js "^1.1.7"
+    keccak "^3.0.0"
+    pbkdf2 "^3.0.17"
+    randombytes "^2.1.0"
+    safe-buffer "^5.1.2"
+    scrypt-js "^3.0.0"
+    secp256k1 "^4.0.1"
+    setimmediate "^1.0.5"
+
+ethereumjs-abi@0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz#5a637ef16ab43473fa72a29ad90871405b3f5241"
+  integrity sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=
+  dependencies:
+    bn.js "^4.10.0"
+    ethereumjs-util "^4.3.0"
+
+ethereumjs-util@^4.3.0:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz#f4bf9b3b515a484e3cc8781d61d9d980f7c83bd0"
+  integrity sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==
+  dependencies:
+    bn.js "^4.8.0"
+    create-hash "^1.1.2"
+    elliptic "^6.5.2"
+    ethereum-cryptography "^0.1.3"
+    rlp "^2.0.0"
+
+ethereumjs-util@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz#a833f0e5fca7e5b361384dc76301a721f537bf65"
+  integrity sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    elliptic "^6.5.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "^0.1.3"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
+
+ethereumjs-util@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz#fcb4e4dd5ceacb9d2305426ab1a5cd93e3163b69"
+  integrity sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
+  dependencies:
+    "@types/bn.js" "^4.11.3"
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    elliptic "^6.5.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.3"
+
+ethjs-util@0.1.6, ethjs-util@^0.1.3:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
+  integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
+  dependencies:
+    is-hex-prefixed "1.0.0"
+    strip-hex-prefix "1.0.0"
 
 event-stream@=3.3.4:
   version "3.3.4"
@@ -5201,7 +5351,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -5718,6 +5868,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hex-prefixed@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
+  integrity sha1-fY035q135dEnFIkTxXPggtd39VQ=
 
 is-installed-globally@^0.1.0:
   version "0.1.0"
@@ -6513,6 +6668,14 @@ jsprim@^1.2.2:
   dependencies:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
+
+keccak@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.1.tgz#ae30a0e94dbe43414f741375cff6d64c8bea0bff"
+  integrity sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==
+  dependencies:
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -7559,6 +7722,11 @@ node-abi@^2.7.0:
   dependencies:
     semver "^5.4.1"
 
+node-addon-api@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
+  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+
 node-addon-api@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.1.0.tgz#98b21931557466c6729e51cb77cd39c965f42239"
@@ -7580,10 +7748,15 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.6.1, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-gyp-build@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
+  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
 node-gyp@^5.0.2, node-gyp@^5.1.0:
   version "5.1.1"
@@ -8465,7 +8638,7 @@ pause-stream@0.0.11:
   dependencies:
     through "~2.3"
 
-pbkdf2@^3.0.3:
+pbkdf2@^3.0.17, pbkdf2@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
   integrity sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==
@@ -8864,7 +9037,7 @@ ramda@~0.26.1:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -9401,6 +9574,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rlp@^2.0.0, rlp@^2.2.3:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.6.tgz#c80ba6266ac7a483ef1e69e8e2f056656de2fb2c"
+  integrity sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==
+  dependencies:
+    bn.js "^4.11.1"
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -9485,6 +9665,20 @@ scheduler@^0.20.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+scrypt-js@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
+
+secp256k1@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.2.tgz#15dd57d0f0b9fdb54ac1fa1694f40e5e9a54f4a1"
+  integrity sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==
+  dependencies:
+    elliptic "^6.5.2"
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
 
 semantic-release@^17.4.0:
   version "17.4.0"
@@ -9605,7 +9799,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -10263,6 +10457,13 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-hex-prefix@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz#0c5f155fef1151373377de9dbb588da05500e36f"
+  integrity sha1-DF8VX+8RUTczd96du1iNoFUA428=
+  dependencies:
+    is-hex-prefixed "1.0.0"
+
 strip-indent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
@@ -10685,10 +10886,20 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tweetnacl-util@^0.15.0:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
+  integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+tweetnacl@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Adds a login handler with the Magic admin SDK.

Adds tests for all happy and sad paths for the login handler using Cypress. Adds the `extractCookies` helper function with tests.

closes #57