### PR TITLE
feat: add get current user handler

### DIFF
--- a/cypress/e2e/user-authentication.spec.ts
+++ b/cypress/e2e/user-authentication.spec.ts
@@ -2,7 +2,42 @@ import { extractCookies } from 'utils/extract-cookies';
 
 import validateForbiddenMethods from '../support/utils';
 
+const getCurrentUserRoute = `/api/user`;
 const loginRoute = `/api/login`;
+
+// TODO: Login and logout using the UI, as well as logout using the API.
+// Depends on Magic updates coming Q2 2021.
+
+describe('get current user handler', () => {
+  context('GET', () => {
+    it('returns a 200 with the user when the user is logged in', () => {
+      cy.loginByCookie().then(session => {
+        cy.request(getCurrentUserRoute).then(response => {
+          expect(response.status).to.equal(200);
+
+          const actual = response.body;
+          const expected = { user: session };
+
+          expect(actual).to.deep.equal(expected);
+        });
+      });
+    });
+
+    it('returns null if the user is logged out', () => {
+      cy.request(getCurrentUserRoute).then(response => {
+        expect(response.status).to.equal(200);
+
+        const actual = response.body;
+        // eslint-disable-next-line unicorn/no-null
+        const expected = { user: null };
+
+        expect(actual).to.deep.equal(expected);
+      });
+    });
+  });
+
+  validateForbiddenMethods(['POST', 'PUT', 'DELETE'], getCurrentUserRoute);
+});
 
 describe('login handler', () => {
   context('GET', () => {

--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -1,0 +1,16 @@
+/// <reference types="cypress" />
+
+type Session = {
+  email: string;
+  issuer: string;
+  publicAddress: string;
+};
+
+declare namespace Cypress {
+  interface Chainable {
+    /**
+     * Logs the user in by adding a session cookie.
+     */
+    loginByCookie(session?: Partial<Session>): Chainable<Session>;
+  }
+}

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -7,7 +7,24 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing).
 
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.local' });
+
+import { encryptSession } from 'utils/sessions';
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const pluginConfig: Cypress.PluginConfig = (on, config) => {};
+const pluginConfig: Cypress.PluginConfig = (on, config) => {
+  on('task', {
+    // In @hapi/iron there is a call to crypto which is a Node library, so we
+    // needed to make encryptSession a task.
+    // https://docs.cypress.io/api/commands/task.html#Syntax
+    encryptSession: (session: {
+      issuer: string;
+      publicAddress: string;
+      email: string;
+    }) => encryptSession(session),
+  });
+};
 
 export default pluginConfig;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -5,3 +5,20 @@
 // ***********************************************
 
 import '@testing-library/cypress/add-commands';
+
+Cypress.Commands.add(
+  'loginByCookie',
+  ({
+    issuer = 'did:example:123456789abcdefghi',
+    publicAddress = '0xDC25EF3F5B8A186998338A2ADA83795FBA2D695E',
+    email = 'jan@janhesters.com',
+  } = {}) => {
+    const session = { issuer, publicAddress, email };
+
+    return cy.task<string>('encryptSession', session).then(token => {
+      return cy.setCookie('magic-auth-token', token).then(() => {
+        return session;
+      });
+    });
+  },
+);

--- a/src/features/user-authentication/get-current-user-handler.ts
+++ b/src/features/user-authentication/get-current-user-handler.ts
@@ -1,0 +1,27 @@
+import type { NextApiHandler } from 'next';
+import { getSession } from 'utils/sessions';
+import type { ApiErrorResponse } from 'utils/types';
+
+import { UserSession } from './types';
+
+type SuccessResponse = {
+  user: UserSession | null;
+};
+
+type GetCurrentUserHandlerResponse = ApiErrorResponse | SuccessResponse;
+
+const getCurrentUserHandler: NextApiHandler<GetCurrentUserHandlerResponse> = async (
+  request,
+  response,
+) => {
+  if (request.method === 'GET') {
+    const session = await getSession(request);
+    // eslint-disable-next-line unicorn/no-null
+    return response.status(200).json({ user: session || null });
+  }
+
+  const message = 'This endpoint only supports the GET method.';
+  return response.status(405).json({ message });
+};
+
+export default getCurrentUserHandler;

--- a/src/pages/api/user.ts
+++ b/src/pages/api/user.ts
@@ -1,0 +1,3 @@
+import userHandler from 'features/user-authentication/get-current-user-handler';
+
+export default userHandler;


### PR DESCRIPTION
Adds a route to get the current user from the session cookie.

Adds tests for the get current user handler when the user is logged in and when they're logged out.

closes #61